### PR TITLE
Fix function to get java version in Linux/MacOS

### DIFF
--- a/tools/logViewer/batect
+++ b/tools/logViewer/batect
@@ -80,7 +80,7 @@
     }
 
     function getJavaVersion() {
-        java -version 2>&1 | head -n1 | sed -En ';s/.* version "([0-9]+)(\.([0-9]+))?.*".*/\1.\3/p;'
+        java -version 2>&1 | grep version | sed -En ';s/.* version "([0-9]+)(\.([0-9]+))?.*".*/\1.\3/p;'
     }
 
     function extractJavaMajorVersion() {

--- a/wrapper/unix/src/template.sh
+++ b/wrapper/unix/src/template.sh
@@ -94,7 +94,7 @@
     }
 
     function getJavaVersion() {
-        java -version 2>&1 | head -n1 | sed -En ';s/.* version "([0-9]+)(\.([0-9]+))?.*".*/\1.\3/p;'
+        java -version 2>&1 | grep version | sed -En ';s/.* version "([0-9]+)(\.([0-9]+))?.*".*/\1.\3/p;'
     }
 
     function extractJavaMajorVersion() {


### PR DESCRIPTION
When `JAVA_TOOL_OPTIONS` environment variable is set, java -version output will contain `Picked up JAVA_TOOL_OPTIONS: xxx` as the first line like below:

```
Picked up JAVA_TOOL_OPTIONS: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
openjdk version "1.8.0_192"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_192-b12)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.192-b12, mixed mode)
```

Instead of assuming version line is always the first line, a more reliable way in my opinion is to grep version line before using sed