### PR TITLE
Fix function to get java version in Linux/MacOS

### DIFF
--- a/tools/logViewer/batect
+++ b/tools/logViewer/batect
@@ -80,7 +80,7 @@
     }
 
     function getJavaVersion() {
-        java -version 2>&1 | head -n1 | sed -En ';s/.* version "([0-9]+)(\.([0-9]+))?.*".*/\1.\3/p;'
+        java -version 2>&1 | grep version | sed -En ';s/.* version "([0-9]+)(\.([0-9]+))?.*".*/\1.\3/p;'
     }
 
     function extractJavaMajorVersion() {

--- a/wrapper/unix/src/template.sh
+++ b/wrapper/unix/src/template.sh
@@ -94,7 +94,7 @@
     }
 
     function getJavaVersion() {
-        java -version 2>&1 | head -n1 | sed -En ';s/.* version "([0-9]+)(\.([0-9]+))?.*".*/\1.\3/p;'
+        java -version 2>&1 | grep version | sed -En ';s/.* version "([0-9]+)(\.([0-9]+))?.*".*/\1.\3/p;'
     }
 
     function extractJavaMajorVersion() {

--- a/wrapper/unix/test/tests.py
+++ b/wrapper/unix/test/tests.py
@@ -112,6 +112,14 @@ class WrapperScriptTests(unittest.TestCase):
                 self.assertIn("The Java application has started.", result.stdout.decode())
                 self.assertEqual(result.returncode, 0)
 
+    def test_supported_java_with_tool_options_set(self):
+        path_dir = self.create_limited_path_for_specific_java_version("8")
+
+        result = self.run_script([], path=path_dir, with_java_tool_options="true")
+
+        self.assertIn("The Java application has started.", result.stdout.decode())
+        self.assertEqual(result.returncode, 0)
+
     def test_non_zero_exit(self):
         result = self.run_script(["exit-non-zero"])
         output = result.stdout.decode()
@@ -139,7 +147,7 @@ class WrapperScriptTests(unittest.TestCase):
 
         return path_dir + ":/bin"
 
-    def run_script(self, args, download_url=default_download_url, path=os.environ["PATH"], quiet_download=None):
+    def run_script(self, args, download_url=default_download_url, path=os.environ["PATH"], quiet_download=None, with_java_tool_options=None):
         env = {
             "BATECT_CACHE_DIR": self.cache_dir,
             "BATECT_DOWNLOAD_URL": download_url,
@@ -148,6 +156,9 @@ class WrapperScriptTests(unittest.TestCase):
 
         if quiet_download is not None:
             env["BATECT_QUIET_DOWNLOAD"] = quiet_download
+
+        if with_java_tool_options is not None:
+            env["JAVA_TOOL_OPTIONS"] = "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
 
         path = self.get_script_path()
         command = [path] + args


### PR DESCRIPTION
When `JAVA_TOOL_OPTIONS` environment variable is set, java -version output will contain `Picked up JAVA_TOOL_OPTIONS: xxx` as the first line like below:

```
Picked up JAVA_TOOL_OPTIONS: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
openjdk version "1.8.0_192"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_192-b12)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.192-b12, mixed mode)
```

Instead of assuming version line is always the first line, a more reliable way in my opinion is to grep version line before using sed