### PR TITLE
Fixes an issue on Macs where the script will silently fail

### DIFF
--- a/wrapper/unix/src/template.sh
+++ b/wrapper/unix/src/template.sh
@@ -114,6 +114,13 @@
             echo "Java is not installed or not on your PATH. Please install it and try again." >&2
             exit 1
         fi
+
+        if [[ "$(uname)" == "Darwin" ]]; then
+            if ! java -version 2>/dev/null; then
+                echo "Java is not installed or not on your PATH. Please install it and try again." >&2
+                exit 1
+            fi
+        fi
     }
 
     function checkJavaVersion() {


### PR DESCRIPTION
Fixes an issue on Macs where the script will silently exit if Java is not installed. Apple has a default java file that displays helper info
"The operation couldn’t be completed. Unable to locate a Java Runtime."
so using hash as a check will always pass. The java file however has an
exit code of 1 so we can check the version for whether this is actually
java installed. I've added this as a specific check for Darwin rather
than replacing the existing logic (minus the Darwin check of course) but
using hash will likely be lighter weight for all other system types
without having to run java -version