### PR TITLE
Remove Groovy left-overs from the code base

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 *.conf           text       eol=lf
 *.editorconfig   text       eol=lf
 *.gradle         text       eol=lf
-*.groovy         text       eol=lf
 *.html           text       eol=lf
 *.java           text       eol=lf
 *.kt             text       eol=lf

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -50,12 +50,6 @@ spotless {
         licenseHeader "/*$licenseText*/\n\n", "(//|apply|def|ext|import|plugins|rootProject|sourceSets|tasks|buildscript|pluginManagement)"
     }
 
-    format "groovy", {
-        target "**/*.groovy"
-
-        licenseHeader "/*$licenseText*/\n\n", "package"
-    }
-
     kotlinGradle {
         target "**/*.gradle.kts"
 

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,6 @@
   "regexManagers": [
     {
       "fileMatch": [
-        ".groovy$",
         ".gradle$",
         ".gradle.kts$"
       ],
@@ -33,7 +32,7 @@
     },
     {
       "fileMatch": [
-        "KotlinPlugin.groovy$"
+        "KotlinPlugin.kt$"
       ],
       "matchStrings": [
         "jacoco {\\s+toolVersion = '(?<currentValue>[\\d.]*?)'"


### PR DESCRIPTION
There is no more Groovy code in the code base, so remove / adjust some
Groovy-specific configuration.