### PR TITLE
Support uid values larger than 2097151 (common for enterprise users)

### DIFF
--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -35,7 +35,7 @@ spotless {
         target fileTree(
             dir: ".",
             include: ["**/*.gradle", "**/*.md", "**/.gitignore", "**/*.yaml", "**/*.yml", "**/*.sh", "**/Dockerfile", "**/*.py", "**/*.json", "**/*.ps1", "**/*.cmd"],
-            excludes: ["**/node_modules/*", "**/build/*"]
+            excludes: ["**/node_modules/*", "**/build/*", "**/.devcontainer/*"]
         )
 
         trimTrailingWhitespace()

--- a/libs/docker-client/src/main/kotlin/batect/docker/api/FilesystemUploadRequestBody.kt
+++ b/libs/docker-client/src/main/kotlin/batect/docker/api/FilesystemUploadRequestBody.kt
@@ -34,6 +34,9 @@ data class FilesystemUploadRequestBody(val contents: Set<ContainerFilesystemItem
         val output = ByteArrayOutputStream()
 
         TarArchiveOutputStream(output).use { archive ->
+            archive.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX)
+            // Required to support a uid larger than 2097151
+            archive.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX)
             contents.forEach { archive.add(it) }
         }
 

--- a/libs/docker-client/src/main/kotlin/batect/docker/build/legacy/ImageBuildContextRequestBody.kt
+++ b/libs/docker-client/src/main/kotlin/batect/docker/build/legacy/ImageBuildContextRequestBody.kt
@@ -32,6 +32,8 @@ data class ImageBuildContextRequestBody(val context: ImageBuildContext) : Reques
     override fun writeTo(sink: BufferedSink) {
         TarArchiveOutputStream(sink.outputStream()).use { output ->
             output.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX)
+            // Required to support a uid larger than 2097151
+            output.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX)
 
             context.entries.forEach { entry ->
                 writeEntry(entry, output)

--- a/libs/docker-client/src/unitTest/kotlin/batect/docker/api/FilesystemUploadRequestBodySpec.kt
+++ b/libs/docker-client/src/unitTest/kotlin/batect/docker/api/FilesystemUploadRequestBodySpec.kt
@@ -42,7 +42,11 @@ object FilesystemUploadRequestBodySpec : Spek({
             val fileBytes = fileContent.toByteArray(Charsets.UTF_8)
 
             val itemsToUpload = setOf(
-                ContainerFile("file-1", 100, 200, fileBytes),
+                // Using a user id larger than 2097151 because this will trigger
+                //   `java.lang.IllegalArgumentException: user id '300000000' is too big ( > 2097151 ).`
+                //   if the underlying TarArchiveOutputStream's bigNumberMode is not set to a
+                //   configuration that will allow large numbers
+                ContainerFile("file-1", 300000001, 200, fileBytes),
                 ContainerDirectory("some-dir", 300, 400)
             )
 
@@ -67,7 +71,7 @@ object FilesystemUploadRequestBodySpec : Spek({
                 assertThat(
                     archive.entries,
                     anyElement(
-                        hasName("file-1") and hasUID(100) and hasGID(200) and isRegularFile() and hasEntrySize(fileBytes.size.toLong())
+                        hasName("file-1") and hasUID(300000001) and hasGID(200) and isRegularFile() and hasEntrySize(fileBytes.size.toLong())
                     )
                 )
 


### PR DESCRIPTION
When my team updated from 0.71.0 to 0.74.0 we started encountering errors such as:
```
Error: An unexpected exception occurred during execution.
During execution of step of kind 'CreateContainerStep': java.lang.IllegalArgumentException: user id '17174830' is too big ( > 2097151 ).
```

From the stack trace given by unit tests, we root-caused the issue to the TarArchiveOutputStream
```
ImageBuildContextRequestBodySpec > a Docker image build context request body > writing the context > given the build context contains a single directory > on writing the request body > batect.docker.build.legacy.ImageBuildContextRequestBodySpec.does not mark the directory as a file FAILED
    java.lang.IllegalArgumentException: user id '17174830' is too big ( > 2097151 ).
        at org.apache.commons.compress.archivers.tar.TarArchiveOutputStream.failForBigNumber(TarArchiveOutputStream.java:651)
        at org.apache.commons.compress.archivers.tar.TarArchiveOutputStream.failForBigNumber(TarArchiveOutputStream.java:639)
        at org.apache.commons.compress.archivers.tar.TarArchiveOutputStream.failForBigNumbers(TarArchiveOutputStream.java:630)
        at org.apache.commons.compress.archivers.tar.TarArchiveOutputStream.putArchiveEntry(TarArchiveOutputStream.java:377)
        at batect.docker.build.legacy.ImageBuildContextRequestBody.writeEntry(ImageBuildContextRequestBody.kt:55)
        at batect.docker.build.legacy.ImageBuildContextRequestBody.writeTo(ImageBuildContextRequestBody.kt:37)
        at batect.docker.build.legacy.ImageBuildContextRequestBodySpec$1$1$3$5$3$1.invoke(ImageBuildContextRequestBodySpec.kt:214)
        at batect.docker.build.legacy.ImageBuildContextRequestBodySpec$1$1$3$5$3$1.invoke(ImageBuildContextRequestBodySpec.kt:214)
```

Based on the conversation in https://github.com/testcontainers/testcontainers-java/pull/4388, it appears that without the POSIX extension to store big numbers, the maximum size of numbers stored in the tar format is quite low. 