### PR TITLE
Fix schema root ID key

### DIFF
--- a/tools/schema/configSchema.json
+++ b/tools/schema/configSchema.json
@@ -1,7 +1,7 @@
 {
   "title": "JSON schema for Batect configuration files",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "id": "https://ide-integration.batect.dev/v1/configSchema.json",
+  "$id": "https://ide-integration.batect.dev/v1/configSchema.json",
   "type": "object",
   "additionalProperties": false,
   "properties": {


### PR DESCRIPTION
Most validators don't seem to care, but schema-07 (and I believe future versions) changed from `"id" to "$id"`, and it's making [ajv](https://ajv.js.org/) throw warnings.