### PR TITLE
Adding new functionality to detect mintty

### DIFF
--- a/libs/os/src/main/kotlin/batect/os/ConsoleInfo.kt
+++ b/libs/os/src/main/kotlin/batect/os/ConsoleInfo.kt
@@ -1,7 +1,7 @@
 /*
     Copyright 2017-2021 Charles Korn.
 
-     Licensed under the Apache License, Version 2.0 (the "License");
+    Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 

--- a/libs/os/src/main/kotlin/batect/os/ConsoleInfo.kt
+++ b/libs/os/src/main/kotlin/batect/os/ConsoleInfo.kt
@@ -1,7 +1,7 @@
 /*
     Copyright 2017-2021 Charles Korn.
 
-    Licensed under the Apache License, Version 2.0 (the "License");
+     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
@@ -65,10 +65,11 @@ class ConsoleInfo(
             data("operatingSystem", systemInfo.operatingSystem)
         }
 
-        stdoutIsTTY && !isTravis && terminalType != "dumb" && (systemInfo.operatingSystem == OperatingSystem.Windows || terminalType != null)
+        (stdoutIsTTY || isMinttyTerminal) && !isTravis && terminalType != "dumb" && (systemInfo.operatingSystem == OperatingSystem.Windows || terminalType != null)
     }
 
     val terminalType: String? = environment["TERM"]
+    private val isMinttyTerminal: Boolean = environment["TERM_PROGRAM"]?.lowercase() == "mintty"
     private val isTravis: Boolean = environment["TRAVIS"] == "true"
 
     @OptIn(ExperimentalSerializationApi::class)

--- a/libs/os/src/unitTest/kotlin/batect/os/ConsoleInfoSpec.kt
+++ b/libs/os/src/unitTest/kotlin/batect/os/ConsoleInfoSpec.kt
@@ -157,6 +157,18 @@ object ConsoleInfoSpec : Spek({
                     assertThat(consoleInfo.supportsInteractivity, equalTo(false))
                 }
             }
+
+            on("STDOUT not being connected to a TTY and environment variable TERM_PROGRAM is set to mintty") {
+                val nativeMethods = mock<NativeMethods> {
+                    on { determineIfStdoutIsTTY() } doReturn false
+                }
+
+                val consoleInfo by createForEachTest { ConsoleInfo(nativeMethods, genericSystemInfo, HostEnvironmentVariables("TERM_PROGRAM" to "mintty"), logger) }
+
+                it("returns true") {
+                    assertThat(consoleInfo.supportsInteractivity, equalTo(true))
+                }
+            }
         }
 
         describe("getting the type of terminal") {

--- a/libs/os/src/unitTest/kotlin/batect/os/ConsoleInfoSpec.kt
+++ b/libs/os/src/unitTest/kotlin/batect/os/ConsoleInfoSpec.kt
@@ -158,15 +158,24 @@ object ConsoleInfoSpec : Spek({
                 }
             }
 
-            on("STDOUT not being connected to a TTY and environment variable TERM_PROGRAM is set to mintty") {
+            describe("on STDOUT not being connected to a TTY") {
                 val nativeMethods = mock<NativeMethods> {
                     on { determineIfStdoutIsTTY() } doReturn false
                 }
 
-                val consoleInfo by createForEachTest { ConsoleInfo(nativeMethods, genericSystemInfo, HostEnvironmentVariables("TERM_PROGRAM" to "mintty"), logger) }
+                on("mintty is being used") {
+                    val consoleInfo by createForEachTest {
+                        ConsoleInfo(
+                            nativeMethods,
+                            genericSystemInfo,
+                            HostEnvironmentVariables("TERM" to "other-terminal", "TERM_PROGRAM" to "mintty"),
+                            logger
+                        )
+                    }
 
-                it("returns true") {
-                    assertThat(consoleInfo.supportsInteractivity, equalTo(true))
+                    it("returns true") {
+                        assertThat(consoleInfo.supportsInteractivity, equalTo(true))
+                    }
                 }
             }
         }


### PR DESCRIPTION
What?
Add a new functionality to detect mintty.

Why?
Running ./batect (the shell script) from "Git Bash" (which uses mintty) that ships with Git for Windows results in the hint:

It looks like Batect is running in a non-interactive session, so it can't ask for permission to collect and report this information. To suppress this message:
* To allow collection of data, set the BATECT_ENABLE_TELEMETRY environment variable to 'true', or run './batect --permanently-enable-telemetry'.
* To prevent collection of data, set the BATECT_ENABLE_TELEMETRY environment variable to 'false', or run './batect --permanently-disable-telemetry'.
However, mintty actually is an interactive session.


Impact?
Low. New functionality.

How to revert changes?
Revert to earlier stable version of code.