### PR TITLE
Add `-h` as an alias for `--help`

### DIFF
--- a/app/src/completionTest/tests/tests.py
+++ b/app/src/completionTest/tests/tests.py
@@ -9,7 +9,6 @@ import uuid
 
 from abc import ABC
 
-
 class CompletionTestBase(ABC):
     def setUp(self):
         cache_directory = os.path.expanduser(os.path.join("~", ".batect"))
@@ -59,6 +58,7 @@ class CompletionTestBase(ABC):
             "--version",
             "-T",
             "-f",
+            "-h",
             "-o",
         ], results)
 

--- a/app/src/main/kotlin/batect/cli/CommandLineOptionsParser.kt
+++ b/app/src/main/kotlin/batect/cli/CommandLineOptionsParser.kt
@@ -63,7 +63,7 @@ class CommandLineOptionsParser(
     private val telemetryOptionsGroup = OptionGroup("Telemetry options")
     private val hiddenOptionsGroup = OptionGroup("Hidden options")
 
-    private val showHelp: Boolean by flagOption(helpOptionsGroup, "help", "Show this help information and exit.")
+    private val showHelp: Boolean by flagOption(helpOptionsGroup, "help", "Show this help information and exit.", 'h')
     private val showVersionInfo: Boolean by flagOption(helpOptionsGroup, "version", "Show Batect version information and exit.")
     private val runUpgrade: Boolean by flagOption(helpOptionsGroup, upgradeFlagName, "Upgrade Batect to the latest available version.")
     private val listTasks: Boolean by flagOption(helpOptionsGroup, "list-tasks", "List available tasks and exit.", 'T')

--- a/app/src/unitTest/kotlin/batect/cli/CommandLineOptionsParserSpec.kt
+++ b/app/src/unitTest/kotlin/batect/cli/CommandLineOptionsParserSpec.kt
@@ -219,6 +219,7 @@ object CommandLineOptionsParserSpec : Spek({
 
         mapOf(
             listOf("--help") to defaultCommandLineOptions.copy(showHelp = true),
+            listOf("-h") to defaultCommandLineOptions.copy(showHelp = true),
             listOf("--help", "some-task") to defaultCommandLineOptions.copy(showHelp = true),
             listOf("--version") to defaultCommandLineOptions.copy(showVersionInfo = true),
             listOf("--version", "some-task") to defaultCommandLineOptions.copy(showVersionInfo = true),


### PR DESCRIPTION
Users typically expect to run `$foo_program -h` for help.  The GNU
standard on command-line options only mentions `--help` and `--version`;
a random survey of typical programs show the large majority using `-h`
as an alias for `--help` (OS-provided, or OSS). There are some legacy
programs (going back to the 1970s and 1980s) treating `-h` otherwise,
but the are a strong minority.

----

I wanted to write a unit test for this.  I looked into `HelpCommandSpec` but did not spot an easy spot that just checked that `--help` was valid syntax so I could update that to `--help` or `-h`.  I haven't used Spek much: *Advice would be welcome*.