### PR TITLE
Gradle: Fix `journeyTestLinuxContainers` to be a `JourneyTest`

### DIFF
--- a/app/gradle/journeyTest.gradle
+++ b/app/gradle/journeyTest.gradle
@@ -75,7 +75,7 @@ tasks.register("journeyTestLinuxContainersNonParallelisable", JourneyTest) {
     onlyIf { !project.properties.containsKey("windowsContainers") }
 }
 
-tasks.register("journeyTestLinuxContainers") {
+tasks.register("journeyTestLinuxContainers", JourneyTest) {
     description "Runs the journey tests for Linux containers."
     group "Verification"
 


### PR DESCRIPTION
This was split from https://github.com/batect/batect/pull/1336 to better isolate some test failures in that PR.